### PR TITLE
Fix infinite whitespace bug in `EnvExampleWriter`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -10,6 +10,7 @@
   },
   "tasks": {
     "dev": "deno run --allow-read='.' --watch main.ts docs .env.example",
+    "dev:example": "deno run --allow-read='.' --watch main.ts example .env.example",
     "run": "deno run --allow-read='.' main.ts docs .env.example"
   },
   "imports": {

--- a/lib/writers/env-example.ts
+++ b/lib/writers/env-example.ts
@@ -16,14 +16,15 @@ export class EnvExampleWriter implements Writer {
   }
 
   writeVariable(variable: Variable, prev: string): string {
-    prev += "#\n";
     variable.description?.split("\n").slice(0, -1).forEach((line) => {
       prev += `# ${line}\n`;
     });
+    // Variable name and default value
     if (variable.optional) {
       prev += "# ";
     }
     prev += `${variable.name}=${variable.defaultValue}\n`;
+    // Additional examples
     variable.examples.forEach((example) => {
       prev += `# ${variable.name}=${example}\n`;
     });


### PR DESCRIPTION
Previously, each iteration added additional empty lines between variables. With this fix, this gets resolved.

### Summary <!-- Summarize the content of the pull request in one sentence -->

n/a

### Details <!-- Describe the content of the pull request -->

n/a

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

n/a

### Related links <!-- Related resources, issues and pull requests -->

- Fixes # .

### CLA

- [ ] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.

<!-- branch-stack -->

- `main`
  - \#14 :point\_left:
