### PR TITLE
Specify the source of the default values in `docs`

### DIFF
--- a/lib/writers/docs.ts
+++ b/lib/writers/docs.ts
@@ -35,7 +35,10 @@ export class DocsWriter implements Writer {
     }
 
     // Default value
-    prev += '#### Default Value\n\n';
+    const defaultSource = variable.optional
+      ? "used by the application if not provided"
+      : "from the example environment file, must be provided";
+    prev += `#### Default Value (${defaultSource})\n\n`;
     prev += this.markdownCodeBlock(`${variable.name}=${variable.defaultValue}`);
 
     // Example values


### PR DESCRIPTION
Previously, the source of the default value was confusing, especially for required variables that, by their very definition, cannot have an application-side default value.

This was now clarified in the output of `envar docs`.

### Summary <!-- Summarize the content of the pull request in one sentence -->

n/a

### Details <!-- Describe the content of the pull request -->

n/a

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

n/a

### Related links <!-- Related resources, issues and pull requests -->

- Fixes # .

### CLA

- [ ] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.

<!-- branch-stack -->

- `main`
  - \#22 :point\_left:
