### PR TITLE
Fix values including an `=` sign in the parser

### DIFF
--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -44,16 +44,16 @@ export function parse(
     // Variables
     if (currentLine.match(/^[a-zA-Z_]+[a-zA-Z0-9_]*=.*$/g)) {
       // Variable definition that's not commented out
-      const [variable, value] = currentLine.split("=", 2);
+      const [variable, ...value] = currentLine.split("=");
       const optional = false; // Didn't begin with a comment
-      ast.registerVariable(variable, optional, value);
+      ast.registerVariable(variable, optional, value.join("="));
       continue;
     }
     if (currentLine.match(/^# [a-zA-Z_]+[a-zA-Z0-9_]*=.*$/g)) {
       // Variable definition that's commented out
-      const [variable, value] = currentLine.split("=", 2);
+      const [variable, ...value] = currentLine.split("=");
       const optional = true; // Didn't begin with a comment
-      ast.registerVariable(variable.slice(2), optional, value);
+      ast.registerVariable(variable.slice(2), optional, value.join("="));
       continue;
     }
 


### PR DESCRIPTION
Previously, values containing an `=`, such as:

```env
URL=https://example.com/abc?x=d
```

didn't include the parts after the `x=`. This commit fixes that.

### Summary <!-- Summarize the content of the pull request in one sentence -->

n/a

### Details <!-- Describe the content of the pull request -->

n/a

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

n/a

### Related links <!-- Related resources, issues and pull requests -->

- Fixes # .

### CLA

- [ ] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.

<!-- branch-stack -->

- `main`
  - \#25 :point\_left:
